### PR TITLE
Fix log handlers

### DIFF
--- a/tools/kcli/kcli/logger.py
+++ b/tools/kcli/kcli/logger.py
@@ -1,6 +1,9 @@
 import logging
 from colorlog import ColoredFormatter
 
+LOGER_NAME = "IRLogger"
+DEFAULT_LOGLEVEL = logging.WARNING
+
 
 debug_formatter = ColoredFormatter(
     "%(log_color)s%(levelname)-8s%(message)s",
@@ -13,17 +16,16 @@ debug_formatter = ColoredFormatter(
     )
 )
 
-def get_logger(log_level=logging.WARNING):
-    # Create stream handler with debug level
-    sh = logging.StreamHandler()
-    sh.setLevel(log_level)
+LOG = logging.getLogger(LOGER_NAME)
+LOG.setLevel(DEFAULT_LOGLEVEL)
 
-    # Add the debug_formatter to sh
-    sh.setFormatter(debug_formatter)
+# def init_logger(log_level=logging.WARNING):
+# Create stream handler with debug level
+sh = logging.StreamHandler()
+sh.setLevel(logging.DEBUG)
 
-    # Create logger and add handler to it
-    logger = logging.getLogger(__name__)
-    logger.setLevel(log_level)
-    logger.addHandler(sh)
+# Add the debug_formatter to sh
+sh.setFormatter(debug_formatter)
 
-    return logger
+# Create logger and add handler to it
+LOG.addHandler(sh)

--- a/tools/kcli/kcli/logger.py
+++ b/tools/kcli/kcli/logger.py
@@ -1,7 +1,7 @@
 import logging
 from colorlog import ColoredFormatter
 
-LOGER_NAME = "IRLogger"
+LOGGER_NAME = "IRLogger"
 DEFAULT_LOGLEVEL = logging.WARNING
 
 
@@ -16,10 +16,9 @@ debug_formatter = ColoredFormatter(
     )
 )
 
-LOG = logging.getLogger(LOGER_NAME)
+LOG = logging.getLogger(LOGGER_NAME)
 LOG.setLevel(DEFAULT_LOGLEVEL)
 
-# def init_logger(log_level=logging.WARNING):
 # Create stream handler with debug level
 sh = logging.StreamHandler()
 sh.setLevel(logging.DEBUG)

--- a/tools/kcli/kcli/main.py
+++ b/tools/kcli/kcli/main.py
@@ -26,12 +26,13 @@ yaml.SafeDumper.add_representer(
 
 
 def dict_lookup(dic, key, *keys):
-    calling_method_name = sys._getframe().f_back.f_code.co_name
-    current_method_name = sys._getframe().f_code.co_name
-    if current_method_name != calling_method_name:
-        full_key = list(keys)
-        full_key.insert(0, key)
-        LOG.debug("looking up the value of \"%s\"" % ".".join(full_key))
+    if LOG.getEffectiveLevel() <= logging.DEBUG:
+        calling_method_name = sys._getframe().f_back.f_code.co_name
+        current_method_name = sys._getframe().f_code.co_name
+        if current_method_name != calling_method_name:
+            full_key = list(keys)
+            full_key.insert(0, key)
+            LOG.debug("looking up the value of \"%s\"" % ".".join(full_key))
     try:
         if key not in dic:
             if isinstance(key, str) and key.isdigit():

--- a/tools/kcli/kcli/yamls.py
+++ b/tools/kcli/kcli/yamls.py
@@ -75,9 +75,6 @@ def _env_constructor(loader, node):
         try:
             return os.environ[loader.construct_scalar(node)]
         except KeyError:
-            # from kcli import main
-            # import kcli
-
             LOG.error("No environment variable named \"%s\" and default"
                          "isn't defined" % node.value)
             sys.exit(1)

--- a/tools/kcli/kcli/yamls.py
+++ b/tools/kcli/kcli/yamls.py
@@ -1,11 +1,14 @@
-import logging
 import yaml
 import sys
 
 from string import ascii_lowercase, digits
 from configure import Configuration
 
-logger = logging.getLogger('logger')
+
+from kcli import logger
+
+
+LOG = logger.LOG
 
 
 def random_generator(size=32, chars=ascii_lowercase + digits):
@@ -72,9 +75,10 @@ def _env_constructor(loader, node):
         try:
             return os.environ[loader.construct_scalar(node)]
         except KeyError:
-            import main
+            # from kcli import main
+            # import kcli
 
-            logger.error("No environment variable named \"%s\" and default"
+            LOG.error("No environment variable named \"%s\" and default"
                          "isn't defined" % node.value)
             sys.exit(1)
 


### PR DESCRIPTION
Mixup in log handlers due to packaging.

Define logger in kcli.logger on load time.
Have all modules grab default logger.
Set loglevel on runtime.

fixes #14 
